### PR TITLE
Add workspace upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,10 @@ from pytopomojo import Topomojo
 
 topomojo = Topomojo("<topomojo_url>", "<topomojo_api_key>")
 topomojo.get_workspaces()
+
+# Upload a workspace archive
+topomojo.upload_workspace("/path/to/workspace.zip")
+
+# Upload multiple workspace archives
+topomojo.upload_workspaces(["/path/one.zip", "/path/two.zip"])
 ```

--- a/pytopomojo/examples/upload-workspace.py
+++ b/pytopomojo/examples/upload-workspace.py
@@ -1,0 +1,11 @@
+# Upload workspace export archives to TopoMojo
+from pytopomojo import Topomojo
+
+# Update the URL and API key to point to your TopoMojo instance
+client = Topomojo("https://example.com/topomojo", "<put your API Key here>")
+
+# Provide the path to a previously exported workspace zip file
+client.upload_workspace("/path/to/workspace.zip")
+
+# Or upload multiple archives
+client.upload_workspaces(["/path/one.zip", "/path/two.zip"])

--- a/pytopomojo/pytopomojo.py
+++ b/pytopomojo/pytopomojo.py
@@ -315,8 +315,8 @@ class Topomojo:
 
     def download_workspaces(self, workspace_ids: List[str], output_file: str) -> None:
         self.logger.debug(f"Downloading an export package for workspaces: {workspace_ids}")
-        
-        url = f"{self.app_url}/api/admin/download"        
+
+        url = f"{self.app_url}/api/admin/download"
         response = self.session.post(url, json=workspace_ids, stream=True)
         
         if response.status_code == 200:
@@ -327,6 +327,51 @@ class Topomojo:
         else:
             # If the request was not successful, raise a custom exception
             raise TopomojoException(response.status_code, response.text)
+
+    def upload_workspace(self, archive_path: str) -> List[str]:
+        """Upload a single workspace export package.
+
+        Parameters
+        ----------
+        archive_path: str
+            Path to a workspace zip file created via ``export_workspace``.
+
+        Returns
+        -------
+        List[str]
+            Identifiers for the uploaded workspaces as returned by the API.
+        """
+
+        self.logger.debug(f"Uploading workspace archive: {archive_path}")
+
+        url = f"{self.app_url}/api/admin/upload"
+
+        with open(archive_path, "rb") as archive:
+            response = self.session.post(url, files={"files": archive})
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise TopomojoException(response.status_code, response.text)
+
+    def upload_workspaces(self, archive_paths: List[str]) -> List[str]:
+        """Upload multiple workspace export packages.
+
+        Parameters
+        ----------
+        archive_paths: List[str]
+            List of paths to workspace zip files to upload.
+
+        Returns
+        -------
+        List[str]
+            Aggregated list of identifiers returned for each uploaded workspace.
+        """
+
+        uploaded_ids: List[str] = []
+        for path in archive_paths:
+            uploaded_ids.extend(self.upload_workspace(path))
+        return uploaded_ids
         
 
     ################################## GAMESPACE FUNCTIONS#####################################################################################


### PR DESCRIPTION
## Summary
- implement `upload_workspace` for single archive uploads
- add `upload_workspaces` wrapper for multiple archives
- document usage in README
- update example script

## Testing
- `python -m py_compile pytopomojo/pytopomojo.py`
- `python -m py_compile pytopomojo/examples/upload-workspace.py`

------
https://chatgpt.com/codex/tasks/task_e_68406f9176f48324ad666f9d36ea7b9a