### PR TITLE
Add automatic version bump commit in release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,28 +4,53 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.x'
 
-      - name: Install build dependencies
+      - name: Update package version from tag
+        id: version
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${TAG#v}"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          VERSION="$(python setup.py --version)"
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "Updating version from $VERSION to $TAG"
+            sed -i -E "s/version=\"[^\"]+\"/version=\"$TAG\"/" setup.py
+          fi
+
+      - name: Commit version bump
+        run: |
+          if git diff --quiet; then
+            echo "Version already up to date"
+          else
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git commit -am "Bump version to $TAG"
+            git push
+          fi
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade build
 
       - name: Build package
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
 
       - name: Publish package
-        run: |
-          python -m twine upload dist/* -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- automatically commit version bumps during the release workflow
- use trusted publisher publishing without an API token

## Testing
- `python -m py_compile setup.py`
- `python -m py_compile pytopomojo/pytopomojo.py`


------
https://chatgpt.com/codex/tasks/task_e_6841ae09027c8324b694ea084824981a