### PR TITLE
Improve devcontainer SSH agent forwarding

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Switch to root for configuring image
 USER root
 
+# Prepare shared SSH agent directory for runtime symlink
+RUN mkdir -p /ssh-agent \
+    && chown vscode:vscode /ssh-agent
+
 # Custom Cert Support
 COPY .devcontainer/certs/ /usr/local/share/ca-certificates/custom/
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,12 +14,17 @@
   "remoteUser": "vscode",
   "mounts": [
     "source=pytopomojo-pip-cache,target=/home/vscode/.cache/pip,type=volume",
-    "source=${localEnv:HOME}/.ssh/config,target=/home/vscode/.ssh/config,type=bind,readonly"
+    "source=${localEnv:HOME}/.ssh/config,target=/home/vscode/.ssh/config,type=bind,readonly",
+    "source=${localEnv:SSH_AUTH_SOCK},target=/ssh-agent/host-agent.sock,type=bind,consistency=cached,readonly"
   ],
+  "remoteEnv": {
+    "SSH_AUTH_SOCK": "/ssh-agent/proxy.sock"
+  },
   "containerEnv": {
     "PIP_DISABLE_PIP_VERSION_CHECK": "1"
   },
   "postCreateCommand": ["bash", "-lc", ".devcontainer/postcreate.sh"],
+  "postStartCommand": ["bash", "-lc", ".devcontainer/scripts/prepare-ssh-agent.sh"],
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/scripts/prepare-ssh-agent.sh
+++ b/.devcontainer/scripts/prepare-ssh-agent.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+SSH_AGENT_DIR=/ssh-agent
+HOST_AGENT_SOCKET="$SSH_AGENT_DIR/host-agent.sock"
+DESKTOP_SOCKET="/run/host-services/ssh-auth.sock"
+PROXY_SOCKET="$SSH_AGENT_DIR/proxy.sock"
+
+mkdir -p "$SSH_AGENT_DIR"
+
+if [ -L "$PROXY_SOCKET" ] || [ -S "$PROXY_SOCKET" ]; then
+  rm -f "$PROXY_SOCKET"
+fi
+
+select_socket() {
+  local candidate=$1
+  if [ -S "$candidate" ] && [ -r "$candidate" ]; then
+    echo "$candidate"
+  fi
+}
+
+CHOSEN_SOCKET="$(select_socket "$HOST_AGENT_SOCKET")"
+if [ -z "$CHOSEN_SOCKET" ]; then
+  CHOSEN_SOCKET="$(select_socket "$DESKTOP_SOCKET")"
+fi
+
+if [ -n "$CHOSEN_SOCKET" ]; then
+  ln -sfn "$CHOSEN_SOCKET" "$PROXY_SOCKET"
+  echo "[devcontainer] SSH agent socket linked to $CHOSEN_SOCKET" >&2
+else
+  cat >&2 <<'MSG'
+[devcontainer] Warning: no SSH agent socket detected.\
+Ensure an SSH agent is running on the host and SSH_AUTH_SOCK is exported before starting the dev container.
+MSG
+fi

--- a/README.md
+++ b/README.md
@@ -23,16 +23,30 @@ This repo includes a VS Code Dev Container for a ready-to-code Linux environment
 
 ### SSH Agent (multiple Git identities supported)
 
-- The devcontainer forwards your host SSH agent using the official `ssh-agent` Feature.
-- Your host `~/.ssh/config` is mounted read‑only to preserve host aliases like `github.com-work` or `github.com-personal`.
+- The dev container reuses your host SSH agent so you can keep separate keys for different GitHub accounts without copying private keys into the container.
+- Your host `~/.ssh/config` is mounted read-only to preserve host aliases like `github.com-work` or `github.com-personal`.
 
-#### Windows setup
+#### Why `/ssh-agent/proxy.sock`?
 
-- Ensure the "OpenSSH Authentication Agent" Windows service is running (set Startup Type to Automatic).
-- Start a PowerShell (or Git Bash) on the host and add your keys:
+Linking the mounted socket to a stable in-container path follows the guidance from the Dev Containers documentation on [sharing Git credentials](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials#_sharing-ssh-keys-with-your-container) and Docker Desktop's instructions for [using the host SSH agent inside a container](https://docs.docker.com/desktop/networking/#use-host-ssh-agent-in-a-container). Both recommend forwarding the host agent through a mounted socket and pointing `SSH_AUTH_SOCK` at that path, which is exactly what the proxy symlink accomplishes.
+
+#### Prepare the host (all platforms)
+
+1. Start an SSH agent and add every key you need (run `ssh-add -l` to verify).
+2. Export `SSH_AUTH_SOCK` in the shell that launches VS Code or runs `devcontainer up`.
+   - macOS / Linux: launching an agent (`eval "$(ssh-agent)"`) usually sets the variable automatically.
+   - Windows: before starting VS Code, set `set SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock` (PowerShell: `$Env:SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock"`).
+3. Keep your host `~/.ssh/config` up to date with the aliases and `IdentityFile` entries for each GitHub account you use.
+
+When the container starts it first attempts to mount the socket referenced by `SSH_AUTH_SOCK`. If that is unavailable (for example on Docker Desktop for Windows), the post-start hook falls back to Docker Desktop's `ssh-auth.sock`, which exposes the same agent to Linux containers.
+
+#### Windows specifics
+
+- Ensure the "OpenSSH Authentication Agent" Windows service is running (Startup Type = Automatic).
+- In PowerShell or Git Bash, add each key to the agent:
   - `ssh-add ~\.ssh\id_ed25519_work`
   - `ssh-add ~\.ssh\id_ed25519_personal`
-- Keep your aliases in `%USERPROFILE%\.ssh\config`, for example:
+- Store aliases in `%USERPROFILE%\.ssh\config`, for example:
 
   ```
   Host github.com-work
@@ -48,22 +62,27 @@ This repo includes a VS Code Dev Container for a ready-to-code Linux environment
     IdentityFile ~/.ssh/id_ed25519_personal
   ```
 
-- Reopen the folder in the devcontainer; keys remain on the host and are available via the agent.
+- Reopen the folder in the dev container; the keys remain on the host and the agent is reused automatically.
 
-#### macOS / Linux setup
+#### macOS / Linux specifics
 
-- Ensure your SSH agent has your keys loaded: `ssh-add -l` (add with `ssh-add ~/.ssh/id_ed25519` if needed).
+- Verify your keys are loaded with `ssh-add -l`; add them with `ssh-add ~/.ssh/id_ed25519_work` as needed.
 - Keep aliases in `~/.ssh/config` as above.
+- The post-start hook links the mounted socket to `/ssh-agent/proxy.sock` and sets `SSH_AUTH_SOCK` accordingly.
 
 #### Verify inside the container
 
-- `ssh -T git@github.com` (or your alias, e.g., `ssh -T git@github.com-work`).
-- `git remote -v` can use alias URLs like `git@github.com-work:org/repo.git`.
+Run the following inside the dev container to confirm everything is wired correctly:
+
+- `ls -l /ssh-agent` — shows `proxy.sock` pointing to the mounted host socket.
+- `ssh-add -l` — the same keys you added on the host should be listed.
+- `ssh -T git@github.com` or `ssh -T git@github.com-work` — GitHub should report successful authentication.
+- `git remote -v` — repositories can use alias URLs like `git@github.com-work:org/repo.git`.
 
 Notes
 
-- Private keys never enter the container; only the agent is forwarded.
-- The devcontainer ensures `~/.ssh/` exists and mounts your `config` file read‑only.
+- Private keys never leave the host; only the forwarded agent socket is exposed inside the container.
+- The dev container ensures `~/.ssh/` exists and mounts your `config` file read-only so aliases are always available.
 
 ## Upload Workspace Example
 


### PR DESCRIPTION
## Summary
- forward the host SSH agent socket into the dev container and configure VS Code to use it
- add a post-start script that links the mounted socket or Docker Desktop host-service socket to a stable path with clearer diagnostics
- document cross-platform SSH agent setup steps in the README, including references to official guidance and verification steps

## Testing
- `.devcontainer/scripts/prepare-ssh-agent.sh` (after linking a host ssh-agent socket inside the container)
- `npm install -g @devcontainers/cli` *(fails: npm registry unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d73287fc2083249f62df9ca5da3d9d